### PR TITLE
Feature/support webhook ring notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,40 @@ In order to configure the intercom you will need to fill the following fields:
 
         _Note: Please open an issue if you would like support added for your intercom._
 
-#### Intercom specific fields:
+#### Intercom Specific Fields:
+
 1. Shelly Uni:
-    - Status Url: `string` _(required)_
-        - URL which retrives the status of the Shelly Uni
-    - Talk Url: `string` _(required)_
-        - URL which triggers Talk button on the Shelly Uni.
-    - Open Url: `string` _(required)_
-        - URL which triggers Open button on the Shelly Uni.
-    - Buttons timeout: `number` _(optional)_
-        - The number of seconds between _pressing_ the Talk button and Open button. Defaults to 1 second.
+
+- Ring Notification Type: `string` _(required)_
+  - Choose how the plugin should detect ringing:
+    - `request`: Exposes a webhook that the Shelly Uni calls.
+    - `poll`: Polls a Shelly Uni endpoint for it's ringing status.
+  - Defaults to `request`.
+- `request` specific fields:
+  - Webhook Port: `number` _(required if using `request`)_
+    - The port on which the webhook will listen for `http://homebridge.ip:port/ringing?status=$value` calls.
+    - Defaults to `9000`.
+- `poll` specific fields:
+  - Status URL: `string` _(required if using `poll`)_
+    - URL which retrieves the status of the Shelly Uni.
+  - Status JSON Path: `string` _(required if using `poll`)_
+    - Path in the JSON structure to the field that changes upon ringing.
+  - Poll Interval: `number` _(required if using `poll`)_
+    - The interval in seconds at which the plugin polls the endpoint for ringing status.
+    - Defaults to `1`.
+- Status Threshold: `number` _(required)_
+  - The minimum value considered as a ringing trigger for `poll` or `request` methods.
+- Talk URL: `string` _(required)_
+  - URL which triggers the Talk button on the Shelly Uni.
+- Open URL: `string` _(required)_
+  - URL which triggers the Open button on the Shelly Uni.
+- Buttons Pressing Order: `string` _(required)_
+  - Some intercoms require different pressing orders. The default one is pressing the Talk button, then the Open button, but others might require an additional press of the Talk or Open button.
+  - Defaults to `open-talk`.
+- Buttons Timeout: `number` _(required)_
+  - The number of seconds between "pressing" the buttons. Defaults to `1` second.
+- Ring Suppression Timeout: `number` _(required)_
+  - The number of seconds to ignore any other changes in the status of the Shelly Uni (changes that imply that the intercom is ringing).
 
 ### Description
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -56,13 +56,46 @@
           }
         ]
       },
+      "shellyUniRingNotificationType": {
+        "title": "Ring Notification Type",
+        "type": "string",
+        "required": true,
+        "description": "Choose how the plugin should detect ringing: 'request' exposes a webhook that the Shelly Uni calls, and 'poll' means the plugin polls an endpoint.",
+        "oneOf": [
+          {
+            "title": "Request",
+            "enum": [
+              "request"
+            ]
+          },
+          {
+            "title": "Poll",
+            "enum": [
+              "poll"
+            ]
+          }
+        ],
+        "default": "request"
+      },
+      "shellyUniWebhookPort": {
+        "title": "Webhook Port",
+        "type": "number",
+        "required": true,
+        "minimum": 1,
+        "maximum": 65535,
+        "default": 9000,
+        "description": "The port on which the webhook will listen for 'http://homebridge.ip:port/ringing?status=$value' calls.\nWARNING: If you're running this in docker you must expose this port to the host.",
+        "condition": {
+          "functionBody": "return model.shellyUniRingNotificationType === 'request' && model.intercomType === \"shellyUni\";"
+        }
+      },
       "shellyUniStatusUrl": {
         "title": "Status URL",
         "type": "string",
         "required": true,
         "description": "URL which retrives the status of the Shelly Uni.",
         "condition": {
-          "functionBody": "return model.intercomType === \"shellyUni\";"
+          "functionBody": "return model.shellyUniRingNotificationType === 'poll' && model.intercomType === \"shellyUni\";"
         }
       },
       "shellyUniStatusJsonPath": {
@@ -72,16 +105,28 @@
         "placeholder": "field1.0.field2",
         "description": "Path in JSON structure to the field that changes upon ringing.",
         "condition": {
-          "functionBody": "return model.intercomType === \"shellyUni\";"
+          "functionBody": "return model.shellyUniRingNotificationType === 'poll' && model.intercomType === \"shellyUni\";"
+        }
+      },
+      "shellyUniPollingInterval": {
+        "title": "Poll Interval",
+        "type": "number",
+        "required": true,
+        "minimum": 1,
+        "maximum": 60,
+        "default": 1,
+        "description": "The interval in seconds at which the plugin polls the endpoint for ringing status. Required if 'ringNotificationType' is set to 'poll'.",
+        "condition": {
+          "functionBody": "return model.shellyUniRingNotificationType === 'poll' && model.intercomType === \"shellyUni\";"
         }
       },
       "shellyUniStatusThreshold": {
         "title": "Status Threshold",
         "type": "number",
-        "required": true,  
+        "required": true,
         "minimum": 1,
         "maximum": 100,
-        "description": "The minimum value of the field that changes upon ringing.",
+        "description": "The minimum value considered as a ringing tirgger for \"poll\" or \"request\" methods.",
         "condition": {
           "functionBody": "return model.intercomType === \"shellyUni\";"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "homebridge-intercom",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-intercom",
-      "version": "1.1.2",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.4"
       },
       "devDependencies": {
-        "@types/node": "^20.7.0",
+        "@types/node": "^22.10.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "@typescript-eslint/parser": "^7.11.0",
         "eslint": "^8.57.0",
@@ -370,12 +370,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -716,9 +717,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -913,10 +915,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1583,20 +1586,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -2364,10 +2353,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -3326,10 +3316,11 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -3381,10 +3372,11 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "homebridge": "^1.8.0",
-        "node": "^18.20.0 || ^20.18.0 || ^22.10.0"
+        "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+        "node": "^18.20.4 || ^20.15.1 || ^22"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/denisgabriel5/homebridge-intercom/issues"
   },
   "engines": {
-    "node": "^18.20.0 || ^20.18.0 || ^22.10.0",
-    "homebridge": "^1.8.0"
+    "node": "^18.20.4 || ^20.15.1 || ^22",
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Intercom",
   "name": "homebridge-intercom",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Manage your old intercom via Homebridge. \nIt consists of two accessories: a doorbell (for checking and notifyng if the intercom rings) and a lock mechanism (for opening the intercom door).",
   "license": "Apache-2.0",
   "homepage": "https://github.com/denisgabriel5/homebridge-intercom",

--- a/src/shellyUni/shellyUniDoorbell.ts
+++ b/src/shellyUni/shellyUniDoorbell.ts
@@ -1,5 +1,6 @@
 import { Characteristic, Service } from 'homebridge';
 import axios from 'axios';
+import http from 'http';
 
 import { IntercomAccessory } from '../intercomAccessory';
 
@@ -9,6 +10,7 @@ export class ShellyUniDoorbell {
   private displayName = 'Doorbell';
   private ringSensorService;
   private ringSuppressed;
+  private server!: http.Server;
 
   public service: Service;
 
@@ -35,35 +37,100 @@ export class ShellyUniDoorbell {
       .onGet(this.handleOccupancyDetectedGet.bind(this));
     this.ringSuppressed = false;
 
-    this.parent.platform.log.debug('Started checking the intercom');
+    if (this.parent.config.shellyUniRingNotificationType === 'request') {
+      this.parent.platform.log.info('Request enabled, initializing webhook...');
+      this.initializeWebhook();
+    } else if (this.parent.config.shellyUniRingNotificationType === 'poll') {
+      this.parent.platform.log.info('Polling enabled, initializing polling...');
+      this.initializePolling();
+    } else {
+      this.parent.platform.log.error('Invalid notification type, please use either "request" or "poll"');
+      return;
+    }
 
-    // continously check the status of the intercom
+    this.parent.platform.log.info('Initialized Shelly Uni Intercom: ', this.parent.accessory.displayName);
+  }
+
+  private initializeWebhook() {
+    this.server = http.createServer(async (req, res) => {
+      if (req.url?.startsWith('/ringing') && req.method === 'GET') {
+        const url = new URL(req.url, `http://${req.headers.host}`);
+        const status = url.searchParams.get('status');
+
+        if (!status) {
+          res.writeHead(400, { 'Content-Type': 'text/plain' });
+          res.end('Bad Request: Missing status parameter');
+          this.parent.platform.log.error('Missing status parameter');
+          return;
+        }
+
+        this.parent.platform.log.info('Received ringing notification with status value: ', status);
+        this.processRingStatus(parseFloat(status!));
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true }));
+      } else {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+      }
+    });
+
+    this.server.listen(this.parent.config.shellyUniWebhookPort!, () => {
+      this.parent.platform.log.info('Intercom plugin is listening for ringing requests on port:', this.parent.config.shellyUniWebhookPort!);
+    });
+  }
+
+  private initializePolling() {
     setInterval(async () => {
       const statusData = (await axios.get(this.parent.config.shellyUniStatusUrl!)).data;
       const status = this.parent.config.shellyUniStatusJsonPath!.split('.').reduce((k, v) => {
         return k && k[v];
       }, statusData);
 
-      if (status > this.parent.config.shellyUniStatusThreshold! &&
-        !this.ringSensorService.getCharacteristic(this.Characteristic.OccupancyDetected).value) {
-        this.parent.platform.log.debug('Intercom rang');
-
-        this.service.updateCharacteristic(this.Characteristic.ProgrammableSwitchEvent, this.ring());
-        this.ringSensorService.updateCharacteristic(this.Characteristic.OccupancyDetected,
-          this.Characteristic.OccupancyDetected.OCCUPANCY_DETECTED);
-
-        this.ringSuppressed = true;
-
-        setTimeout(async () => {
-          this.ringSuppressed = false;
-        }, this.parent.config.shellyUniRingSuppressionTimeout! * 1000);
+      if (status === undefined) {
+        this.parent.platform.log.error('Status value is undefined, please check your configuration');
+        return;
       }
 
-      if (status < this.parent.config.shellyUniStatusThreshold! && !this.ringSuppressed) {
+      this.parent.platform.log.debug('Checking status of the intercom: ', status);
+      this.processRingStatus(parseFloat(status!));
+    }, this.parent.config.shellyUniPollingInterval * 1000);
+  }
+
+  private processRingStatus(status: number) {
+    const statusThreshold = parseFloat(this.parent.config.shellyUniStatusThreshold!);
+    if (status < statusThreshold) {
+      if (this.ringSensorService.getCharacteristic(this.Characteristic.OccupancyDetected).value ===
+        this.Characteristic.OccupancyDetected.OCCUPANCY_DETECTED) {
+        this.parent.platform.log.info('Ringing stopped, clear occupancy detected status');
         this.ringSensorService.updateCharacteristic(this.Characteristic.OccupancyDetected,
           this.Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED);
+      } else {
+        this.parent.platform.log.debug('Status is below threshold, ignoring notification');
       }
-    }, 1000);
+      return;
+    }
+
+    if (this.ringSuppressed) {
+      this.parent.platform.log.debug('Ring suppressed, ignoring notification');
+      return;
+    }
+
+    this.parent.platform.log.info('Intercom rang');
+
+    this.service.updateCharacteristic(this.Characteristic.ProgrammableSwitchEvent, this.ring());
+    this.ringSensorService.updateCharacteristic(this.Characteristic.OccupancyDetected,
+      this.Characteristic.OccupancyDetected.OCCUPANCY_DETECTED);
+
+    this.parent.platform.log.info('Ring suppressed for: ', this.parent.config.shellyUniRingSuppressionTimeout, ' seconds');
+    this.ringSuppressed = true;
+
+    setTimeout(() => {
+      this.ringSuppressed = false;
+      this.ringSensorService.updateCharacteristic(this.Characteristic.OccupancyDetected,
+        this.Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED);
+      this.parent.platform.log.info('Ring suppression timeout ended');
+    }, this.parent.config.shellyUniRingSuppressionTimeout! * 1000);
   }
 
   /**

--- a/src/shellyUni/shellyUniLockMechanism.ts
+++ b/src/shellyUni/shellyUniLockMechanism.ts
@@ -15,7 +15,7 @@ export class ShellyUniLockMechanism {
     this.Characteristic = this.parent.platform.api.hap.Characteristic;
 
     this.service = this.parent.accessory.getService(this.displayName) ||
-        this.parent.accessory.addService(this.Service.LockMechanism, this.displayName);
+      this.parent.accessory.addService(this.Service.LockMechanism, this.displayName);
 
     this.service.setCharacteristic(this.Characteristic.Name, this.displayName);
 
@@ -72,12 +72,12 @@ export class ShellyUniLockMechanism {
       switch (buttons[i]) {
         case 'open':
           axios.get(this.parent.config.shellyUniOpenUrl!);
-          this.parent.platform.log.debug('Intercom Open button pressed');
+          this.parent.platform.log.info('Intercom Open button pressed');
           break;
 
         case 'talk':
           axios.get(this.parent.config.shellyUniTalkUrl!);
-          this.parent.platform.log.debug('Intercom Talk button pressed');
+          this.parent.platform.log.info('Intercom Talk button pressed');
           break;
 
         default:
@@ -89,7 +89,7 @@ export class ShellyUniLockMechanism {
         // mark the intercom as open/unlocked/unsecured
         this.service.updateCharacteristic(this.Characteristic.LockTargetState, this.Characteristic.LockCurrentState.UNSECURED);
         this.service.updateCharacteristic(this.Characteristic.LockCurrentState, this.Characteristic.LockCurrentState.UNSECURED);
-        this.parent.platform.log.debug('Intercom opened');
+        this.parent.platform.log.info('Intercom opened');
 
         break;
       } else {
@@ -101,7 +101,7 @@ export class ShellyUniLockMechanism {
     setTimeout(() => {
       this.service.updateCharacteristic(this.Characteristic.LockTargetState, this.Characteristic.LockCurrentState.SECURED);
       this.service.updateCharacteristic(this.Characteristic.LockCurrentState, this.Characteristic.LockCurrentState.SECURED);
-      this.parent.platform.log.debug('Intercom closed');
+      this.parent.platform.log.info('Intercom closed');
     }, this.parent.config.timeout! * 1000);
   }
 


### PR DESCRIPTION
The changes in this PR primarily focus on adding support for a new methods of detecting intercom ringing: **webhook requests**.  The original method of polling the shelly for it's status value is still avaliable in the configuration togther with a new field where you can customize the polling interval.

Here's a summary of the changes:

### 1. **Configuration Schema Updates**
- Added a new property `shellyUniRingNotificationType` to specify the ringing detection method (`poll` or `request`).
- Added `shellyUniWebhookPort` for webhook-based detection.
- Added a new `shellyUniPollingInterval` config field to customize polling interval.
- Updated conditions for `shellyUniStatusUrl`, `shellyUniStatusJsonPath`, and `shellyUniPollingInterval` to apply only when the `poll` method is selected.
- `shellyUniWebhookPort` only applies for the `request` detection method.

### 2. **Webhook Support in `ShellyUniDoorbell`**
- Introduced a webhook server using the `http` module to listen for incoming requests at `/ringing`.
- The webhook processes the `status` parameter from the request and triggers the ring logic if the `status` value is above the configured threshold.
- Example notification request `http://homebridge.ip:$shellyUniWebhookPort/ringing?status=25.4`

### 3. **Polling Enhancements in `ShellyUniDoorbell`**
- Added logic to continuously poll the `shellyUniStatusUrl` at intervals defined by `shellyUniPollingInterval`.
- Improved error handling for undefined or invalid status values.

### 4. **General Improvements**
- Enhanced logging for better debugging and clarity.
- Improved readability by introducing a `processRingStatus` function
- Added support for Homebridge V2.

### 5. **Version Updates**
- Updated the package.json version to `1.4.0`.
- Updated dependencies in package-lock.json.

These changes allow the plugin to support both webhook-based and polling-based ringing detection, making it more flexible for different setups.